### PR TITLE
Redirect stdout to stderr when running Django setup

### DIFF
--- a/pylint_django/checkers/foreign_key_strings.py
+++ b/pylint_django/checkers/foreign_key_strings.py
@@ -7,6 +7,7 @@ from pylint.interfaces import IAstroidChecker
 
 from pylint_django.__pkginfo__ import BASE_ID
 from pylint_django.transforms import foreignkey
+from pylint_django.utils import redirect_stdout_to_stderr
 
 
 class ForeignKeyStringsChecker(BaseChecker):
@@ -89,7 +90,8 @@ Consider passing in an explicit Django configuration file to match your project 
         try:
             import django  # pylint: disable=import-outside-toplevel
 
-            django.setup()
+            with redirect_stdout_to_stderr():
+                django.setup()
             from django.apps import (  # noqa pylint: disable=import-outside-toplevel,unused-import
                 apps,
             )
@@ -108,7 +110,8 @@ Consider passing in an explicit Django configuration file to match your project 
                 )
 
                 settings.configure()
-                django.setup()
+                with redirect_stdout_to_stderr():
+                    django.setup()
             else:
                 # see if we can load the provided settings module
                 try:
@@ -118,7 +121,8 @@ Consider passing in an explicit Django configuration file to match your project 
                     )
 
                     settings.configure(Settings(self.config.django_settings_module))
-                    django.setup()
+                    with redirect_stdout_to_stderr():
+                        django.setup()
                 except ImportError:
                     # we could not find the provided settings module...
                     # at least here it is a fatal error so we can just raise this immediately
@@ -132,7 +136,8 @@ Consider passing in an explicit Django configuration file to match your project 
                     )
 
                     settings.configure()
-                    django.setup()
+                    with redirect_stdout_to_stderr():
+                        django.setup()
 
         # Now we can add the transforms specific to this checker
         foreignkey.add_transform(astroid.MANAGER)

--- a/pylint_django/transforms/foreignkey.py
+++ b/pylint_django/transforms/foreignkey.py
@@ -3,7 +3,7 @@ from itertools import chain
 from astroid import MANAGER, InferenceError, UseInferenceDefault, inference_tip, nodes
 from astroid.nodes import Attribute, ClassDef
 
-from pylint_django.utils import node_is_subclass
+from pylint_django.utils import node_is_subclass, redirect_stdout_to_stderr
 
 
 def is_foreignkey_in_class(node):
@@ -41,7 +41,8 @@ def _get_model_class_defs_from_module(module, model_name, module_name):
 def _module_name_from_django_model_resolution(model_name, module_name):
     import django  # pylint: disable=import-outside-toplevel
 
-    django.setup()
+    with redirect_stdout_to_stderr():
+        django.setup()
     from django.apps import apps  # pylint: disable=import-outside-toplevel
 
     app = apps.get_app_config(module_name)

--- a/pylint_django/utils.py
+++ b/pylint_django/utils.py
@@ -1,7 +1,7 @@
 """Utils."""
-from contextlib import contextmanager
 import os
 import sys
+from contextlib import contextmanager
 
 import astroid
 from astroid.bases import Instance

--- a/pylint_django/utils.py
+++ b/pylint_django/utils.py
@@ -1,4 +1,6 @@
 """Utils."""
+from contextlib import contextmanager
+import os
 import sys
 
 import astroid
@@ -38,3 +40,11 @@ def is_migrations_module(node):
         return False
 
     return "migrations" in node.path[0] and not node.path[0].endswith("__init__.py")
+
+
+@contextmanager
+def redirect_stdout_to_stderr():
+    orig_stdout = sys.stdout
+    sys.stdout = sys.stderr
+    yield
+    sys.stdout = orig_stdout


### PR DESCRIPTION
This prevents from a malformed JSON being created if any stdout output is made during Django setup, e.g.: print().

Signed-off-by: Noam Stolero <nstolero@barracuda.com>