### PR TITLE
Crash when using commandline flags

### DIFF
--- a/pylint_django/checkers/foreign_key_strings.py
+++ b/pylint_django/checkers/foreign_key_strings.py
@@ -117,7 +117,7 @@ Consider passing in an explicit Django configuration file to match your project 
                         settings,
                     )
 
-                    new_settings = Settings(self.config.django_settings_module)
+                    Settings(self.config.django_settings_module)
                     assert settings.configured
 
                     django.setup()

--- a/pylint_django/checkers/foreign_key_strings.py
+++ b/pylint_django/checkers/foreign_key_strings.py
@@ -117,7 +117,9 @@ Consider passing in an explicit Django configuration file to match your project 
                         settings,
                     )
 
-                    settings.configure(Settings(self.config.django_settings_module))
+                    new_settings = Settings(self.config.django_settings_module)
+                    assert settings.configured
+
                     django.setup()
                 except ImportError:
                     # we could not find the provided settings module...


### PR DESCRIPTION
Fix #385 

The issue is that creating the `Settings` objects already configures the `settings`.