### PR TITLE
Fix the CI and remove deprecated python interpreter and django versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
+        python-version: ["3.11"]
         toxenv: [django_not_installed, flake8, pylint, readme]
 
     steps:
@@ -31,80 +31,11 @@ jobs:
             export PYTHON=${{ matrix.python-version }}
             tox
 
-
-  test:
-    name: test latest / Django@${{ matrix.django-version }} / Python@${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
-        django-version: [-main, "4.0"]
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Execute tests
-        run: |
-            pip install -U pip poetry tox
-            poetry install -E for_tests
-
-            export DJANGO=${{ matrix.django-version }}
-            export PYTHON=${{ matrix.python-version }}
-            export TOXENV=$(echo py${{ matrix.python-version }}-django${{ matrix.django-version }} | tr -d .)
-            tox
-
-      - name: Coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-            pip install coveralls
-            coveralls --service=github
-
-  test_deprecated:  # testing older versions of python+django
-    name: test old stuff / Django@${{ matrix.django-version }} / Python@${{ matrix.python-version }}
-    runs-on: ubuntu-latest
-    strategy:  # TODO: use a YAML anchor - not supported in GitHub actions "yet"
-      fail-fast: false
-      matrix:
-        python-version: [3.7, 3.8, 3.9]
-        django-version: [3.2, 3.1, "3.0", "2.0", "2.2", "1.11"]
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Execute tests
-        run: |
-            pip install -U pip poetry tox
-            poetry install -E for_tests
-
-            export DJANGO=${{ matrix.django-version }}
-            export PYTHON=${{ matrix.python-version }}
-            export TOXENV=$(echo py${{ matrix.python-version }}-django${{ matrix.django-version }} | tr -d .)
-            tox
-
-      - name: Coveralls
-        env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-            pip install coveralls
-            coveralls --service=github
-
   build_and_package_sanity:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ["3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,80 @@
+name: tests
+
+on:
+  push:
+    branches: master
+  pull_request:
+jobs:
+  test:
+    name: latest / Django@${{ matrix.django-version }} / Python@${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.8, 3.9, "3.10", "3.11"]
+        django-version: [-main, "4.2"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Execute tests
+        run: |
+            pip install -U pip poetry tox
+            poetry install -E for_tests
+
+            export DJANGO=${{ matrix.django-version }}
+            export PYTHON=${{ matrix.python-version }}
+            export TOXENV=$(echo py${{ matrix.python-version }}-django${{ matrix.django-version }} | tr -d .)
+            tox
+
+      - name: Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            pip install coveralls
+            coveralls --service=github
+
+  test_lts:  # testing older versions of python+django
+    name: LTS / Django@${{ matrix.django-version }} / Python@${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:  # TODO: use a YAML anchor - not supported in GitHub actions "yet"
+      fail-fast: false
+      matrix:
+        python-version: [3.8, 3.9, "3.10", "3.11"]
+        django-version: [
+          # See  https://www.djangoproject.com/download/
+          # You must also modify the tox.ini if you touch this !
+          # "4.2", # EOL Extended April 2026
+          "3.2", # EOL Extended April 2024
+          "4.1", # EOL Extended December 2023
+        ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Execute tests
+        run: |
+            pip install -U pip poetry tox
+            poetry install -E for_tests
+
+            export DJANGO=${{ matrix.django-version }}
+            export PYTHON=${{ matrix.python-version }}
+            export TOXENV=$(echo py${{ matrix.python-version }}-django${{ matrix.django-version }} | tr -d .)
+            tox
+
+      - name: Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            pip install coveralls
+            coveralls --service=github

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
             export DJANGO=${{ matrix.django-version }}
             export PYTHON=${{ matrix.python-version }}
             export TOXENV=$(echo py${{ matrix.python-version }}-django${{ matrix.django-version }} | tr -d .)
-            tox
+            tox -v
 
       - name: Coveralls
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,18 +12,11 @@ classifiers=[
     "Operating System :: Unix",
     "Topic :: Software Development :: Quality Assurance",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Framework :: Django :: 2.2",
-    "Framework :: Django :: 3",
-    "Framework :: Django :: 3.0",
-    "Framework :: Django :: 3.1",
     "Framework :: Django :: 3.2",
-    "Framework :: Django :: 4",
-    "Framework :: Django :: 4.0",
     "Framework :: Django :: 4.1",
     "Framework :: Django :: 4.2",
     "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
@@ -40,7 +33,7 @@ include = [
 exclude = ["**/tests/**", "**/testutils.py", "**/tests.py"]
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4.0"
+python = ">=3.8,<4.0"
 pylint-plugin-utils = ">=0.8"
 pylint = ">=2.0,<3"
 Django = {version=">=2.2", optional = true}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,3 +66,8 @@ include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
 line_length = 120
+
+[tool.pylint.main]
+disable = ["missing-docstring","too-many-branches","too-many-return-statements","too-many-ancestors","fixme"]
+ignore="tests"
+max-line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ django-tastypie = {version="^0.14.5", optional = true}
 tox = "^4.5.1"
 pytest = "^7.3.1"
 pylint = ">=2.13"
-coverage = "^7.2.5"
+pytest-cov = "^4.1.0"
 twine = "^4.0.2"
 wheel = "^0.40.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ django-tastypie = {version="^0.14.5", optional = true}
 tox = "^4.5.1"
 pytest = "^7.3.1"
 pylint = ">=2.13"
-pytest-cov = "^4.1.0"
+coverage = "^7.2.5"
 twine = "^4.0.2"
 wheel = "^0.40.0"
 

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
     flake8: flake8 pylint_django/
     pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django
     readme: bash -c "poetry build && twine check dist/*"
-    py{38,39,310,311}-django{32,41,42}: coverage run pylint_django/tests/test_func.py -v
+    py{38,39,310,311}-django{32,41,42}: pytest --cov=pylint_django pylint_django/tests/test_func.py -v
     clean: find . -type f -name '*.pyc' -delete
     clean: find . -type d -name __pycache__ -delete
     clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,9 @@ envlist =
     flake8
     pylint
     readme
-    py{37,38,39}-django{22,30,31,32}
-    py{38,39,310,311}-django{40,41,42}
+    # You must also modify the .github/workflows/build.yml if you touch this !
+    py{38,39,310,311}-django{32,41}
+    py{38,39,310,311}-django{42}
 
 requires =
     pip >=21.0.1
@@ -21,7 +22,7 @@ commands =
     flake8: flake8 pylint_django/
     pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django
     readme: bash -c "poetry build && twine check dist/*"
-    py{37,38,39,310,311}-django{22,30,31,32,40,41,42}: coverage run pylint_django/tests/test_func.py -v
+    py{38,39,310,311}-django{32,41,42}: coverage run pylint_django/tests/test_func.py -v
     clean: find . -type f -name '*.pyc' -delete
     clean: find . -type d -name __pycache__ -delete
     clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/
@@ -31,11 +32,7 @@ deps =
     pylint: Django
     readme: twine
     readme: wheel
-    django22: Django>=2.2,<3.0
-    django30: Django>=3.0,<3.1
-    django31: Django>=3.1,<3.2
     django32: Django>=3.2,<4.0
-    django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
     django-main: Django
@@ -47,7 +44,7 @@ setenv =
 allowlist_externals =
     django_not_installed: bash
     readme: bash
-    py{37,38,39,310,311}-django{22,30,31,32,40,41,42}: coverage
+    py{38,39,310,311}-django{32,41,42}: coverage
     clean: find
     clean: rm
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ requires =
 commands =
     django_not_installed: bash pylint_django/tests/test_django_not_installed.sh
     flake8: flake8 pylint_django/
-    pylint: pylint --rcfile=tox.ini -d missing-docstring,too-many-branches,too-many-return-statements,too-many-ancestors,fixme --ignore=tests pylint_django
+    pylint: pylint pylint_django
     readme: bash -c "poetry build && twine check dist/*"
     py{38,39,310,311}-django{32,41,42}: pytest --cov=pylint_django pylint_django/tests/test_func.py -v
     clean: find . -type f -name '*.pyc' -delete
@@ -51,8 +51,7 @@ allowlist_externals =
 [flake8]
 max-line-length = 120
 
-[pylint]
-max-line-length = 120
+
 
 [FORMAT]
 max-line-length=120

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
     flake8: flake8 pylint_django/
     pylint: pylint pylint_django
     readme: bash -c "poetry build && twine check dist/*"
-    py{38,39,310,311}-django{32,41,42}: pytest --cov=pylint_django pylint_django/tests/test_func.py -v
+    py{38,39,310,311}-django{32,41,42}: coverage run pylint_django/tests/test_func.py -v
     clean: find . -type f -name '*.pyc' -delete
     clean: find . -type d -name __pycache__ -delete
     clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/


### PR DESCRIPTION
@carlio I've been working on this on the side, it's not ready yet but do you agree with the removal of python interpreters and django versions ? I don't know what the exact issue is buy my intuition is that we have a combination of two things:
- tox output is not easy to debug so launching things directly in the github action instead of tox could help with debug
- There might be incompatibilities between some elements of the test matrices (django 4.2 not available in python 3.8, that kind of things), so changing to a more hard coded approach might help remove them
What do you think ?

Refs #376