### PR TITLE
use django aliases for ranges to support psycopg 2 and 3

### DIFF
--- a/pylint_django/transforms/fields.py
+++ b/pylint_django/transforms/fields.py
@@ -79,7 +79,10 @@ def apply_type_shim(cls, _context=None):
     elif cls.name in ("HStoreField", "JSONField"):
         base_nodes = scoped_nodes.builtin_lookup("dict")
     elif cls.name in _RANGE_FIELDS:
-        base_nodes = MANAGER.ast_from_module_name("psycopg2._range").lookup("Range")
+        try:
+            base_nodes = MANAGER.ast_from_module_name("django.db.backends.postgresql.psycopg_any").lookup("Range")
+        except AstroidImportError:
+            base_nodes = MANAGER.ast_from_module_name("psycopg2._range").lookup("Range")
     else:
         return iter([cls])
 


### PR DESCRIPTION
Django 4.2 introduces support for psycopg 3, but when using psycopg 3 Ranges without psycopg2 install, pyling-django raises an AstroidImportError due to `apply_type_shim` checking for `psycopg2._range`. Django 4.2 also now provides aliases to the Ranges in the appropriate library. This change uses these aliases for checking and falls back using `psycopg2` if they are not available (running Django <4.2).