### PR TITLE
Actually run the tests and also run them against Django 4.1-5.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,22 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
-        django-version: [-main, "4.0"]
+        django-version: [-main, "5.0", "4.2", "4.1", "4.0"]
+        exclude:
+          - python-version: "3.8"
+            django-version: -main
+          - python-version: "3.8"
+            django-version: "5.0"
+          - python-version: "3.9"
+            django-version: -main
+          - python-version: "3.9"
+            django-version: "5.0"
+          - python-version: "3.12"
+            django-version: "4.2"
+          - python-version: "3.12"
+            django-version: "4.1"
+          - python-version: "3.12"
+            django-version: "4.0"
 
     steps:
       - uses: actions/checkout@v3

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,4 +10,4 @@ pip install pytest pytest-cov \
   "django-tastypie>=0.14.6" \
   "djangorestframework>=3.13.1"
 
-python pylint_django/tests/test_func.py -v "$@"
+python -m pytest pylint_django/tests/test_func.py -v "$@"

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,9 @@ envlist =
     pylint
     readme
     py{37,38,39}-django{22,30,31,32}
-    py{38,39,310,311}-django{40,41,42}
+    py{38,39,310,311}-django{40,41}
+    py{38,39,310,311,312}-django{42}
+    py{310,311,312}-django{50,-main}
 
 requires =
     pip >=21.0.1
@@ -21,7 +23,7 @@ commands =
     flake8: flake8 pylint_django/
     pylint: pylint pylint_django
     readme: bash -c "poetry build && twine check dist/*"
-    py{37,38,39,310,311}-django{22,30,31,32,40,41,42}: bash scripts/test.sh --cov=pylint_django
+    django{22,30,31,32,40,41,42,50,-main}: bash scripts/test.sh --cov=pylint_django
     clean: find . -type f -name '*.pyc' -delete
     clean: find . -type d -name __pycache__ -delete
     clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/
@@ -38,6 +40,7 @@ deps =
     django40: Django>=4.0,<4.1
     django41: Django>=4.1,<4.2
     django42: Django>=4.2,<4.3
+    django50: Django>=5.0,<5.1
     django-main: Django
     django-main: git+https://github.com/pycqa/astroid@main
     django-main: git+https://github.com/pycqa/pylint@main
@@ -47,6 +50,6 @@ setenv =
 allowlist_externals =
     django_not_installed: bash
     readme: bash
-    py{37,38,39,310,311}-django{22,30,31,32,40,41,42}: bash
+    django{22,30,31,32,40,41,42,50,-main}: bash
     clean: find
     clean: rm


### PR DESCRIPTION
When `scripts/test.sh` was introduced back in commit https://github.com/pylint-dev/pylint-django/commit/55cb670049b1d2d2219ea0968ef55f1e914e055d, [`test_func.py`](https://github.com/pylint-dev/pylint-django/blob/55cb670049b1d2d2219ea0968ef55f1e914e055d/test/test_func.py) had

```python
if __name__=='__main__':
    testlib.unittest_main(defaultTest='suite')
```

Commit https://github.com/pylint-dev/pylint-django/commit/38f2cf2e7f0909f17b6a0d67a37b89c2ffc678b0 (PR pylint-dev/pylint-django#417) removed 

```python
if __name__ == "__main__":
    sys.exit(pytest.main(sys.argv))
```

The tests on the main branch pass, but as the [logs](https://github.com/pylint-dev/pylint-django/actions/runs/8055242581) show, pytest never runs.  And the coverage shows 0%.

----

In my fork all tests for `test old stuff / Django@… / Python@3.7` don't do anything after `Resolving dependencies...` and I've cancelled the workflow after 18 minutes.  Maybe support for Python 3.7 can be dropped?  It [reached its EOL](https://peps.python.org/pep-0537/#lifespan) back in 2023-06-27.  Django 3.2 LTS is the last version that supports Python 3.7 and that will [reach its EOL in April 2024](https://www.djangoproject.com/download/).