### PR TITLE
Run ruff with tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ commands =
     clean: find . -type d -name __pycache__ -delete
     clean: rm -rf build/ .cache/ dist/ .eggs/ pylint_django.egg-info/ .tox/
 deps =
-    ruff: ruff
     pylint: pylint<3
     pylint: Django
     readme: twine
@@ -50,3 +49,7 @@ allowlist_externals =
     py{37,38,39,310,311}-django{22,30,31,32,40,41,42}: bash
     clean: find
     clean: rm
+
+[testenv:ruff]
+commands = ruff check
+deps = ruff


### PR DESCRIPTION
PR pylint-dev/pylint-django#414 switched to ruff, but forgot to add it to the commands section.