### PR TITLE
Keep Field in the type shim so super() calls resolve

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,3 +22,4 @@
 - [dineshtrivedi](https://github.com/dineshtrivedi)
 - [matejsp](https://github.com/matejsp)
 - [joewesch](https://github.com/joewesch)
+- [aviseth](https://github.com/aviseth)

--- a/pylint_django/tests/input/func_noerror_field_subclass_super.py
+++ b/pylint_django/tests/input/func_noerror_field_subclass_super.py
@@ -1,0 +1,61 @@
+"""
+Checks that Pylint does not emit no-member when a subclass of a shimmed
+model field calls a `Field` method through `super()`.
+
+The type shim in `pylint_django.transforms.fields` replaces a field's inferred
+bases with the runtime type it behaves like (`str` for CharField, `uuid.UUID`
+for UUIDField, and so on). `Field` itself has to stay in that list, or every
+method defined on it -- `pre_save`, `get_prep_value`, `contribute_to_class`,
+`get_default`, `clean` -- disappears from the MRO that `super()` resolves
+against, and each call raises a false E1101.
+"""
+#  pylint: disable=missing-class-docstring,missing-function-docstring
+
+from django.db import models
+
+
+class TruncatingCharField(models.CharField):
+    def get_prep_value(self, value):
+        value = super().get_prep_value(value)
+        if value:
+            return value[: self.max_length]
+        return value
+
+    def clean(self, value, model_instance):
+        cleaned = super().clean(value, model_instance)
+        return cleaned.strip()
+
+
+class OffsetIntegerField(models.IntegerField):
+    def get_default(self):
+        return super().get_default() or 0
+
+    def contribute_to_class(self, cls, name, private_only=False):
+        super().contribute_to_class(cls, name, private_only=private_only)
+        setattr(cls, f"{name}_offset", 1)
+
+
+class UuidField(models.UUIDField):
+    def pre_save(self, model_instance, add):
+        value = super().pre_save(model_instance, add)
+        if value is None and add:
+            return self.get_default()
+        return value
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        kwargs.pop("default", None)
+        return name, path, args, kwargs
+
+
+class StampedDateTimeField(models.DateTimeField):
+    def pre_save(self, model_instance, add):
+        value = super().pre_save(model_instance, add)
+        print(value)
+        return value
+
+
+class DefaultingJSONField(models.JSONField):
+    def get_default(self):
+        default = super().get_default()
+        return default if default else {}

--- a/pylint_django/transforms/fields.py
+++ b/pylint_django/transforms/fields.py
@@ -110,9 +110,9 @@ def apply_type_shim(cls, _context=None):  # pylint: disable=too-many-statements
 
     # Add all ancestors inheriting from Field
     for ancestor in cls.ancestors():
+        base_nodes.append(ancestor)
         if ancestor.qname() == "django.db.models.fields.Field":
             break
-        base_nodes.append(ancestor)
 
     return iter([cls, *base_nodes])
 


### PR DESCRIPTION
Closes #477.

Reproduced on master with pylint 4.0.7 and Django 6.1 — eight false `no-member` on a handful of field subclasses.

What narrows it down: it only happens for field types in the shim table. A subclass of `models.Field` or `models.BinaryField`, which aren't in it, is clean. A subclass of `UUIDField` or `CharField` isn't.

`apply_type_shim` swaps a field's inferred bases for the type it behaves like at runtime — `str` for CharField, `uuid.UUID` for UUIDField. 778342f added a loop putting the ancestors back so pylint 4 could still see them, but it breaks on `Field` before appending it. `pre_save`, `get_prep_value`, `contribute_to_class`, `get_default`, `clean` and `deconstruct` all live on `Field`, so all of them drop out of the MRO that `super()` resolves against, and every call through `super()` to one of them is reported missing.

Moving the append above the break keeps the loop's bound exactly where it was: `Field` is the last entry, nothing above it is added.

One consequence worth knowing before you merge. With `Field` back in the MRO, pylint can compare signatures again, so an override like `contribute_to_class(self, cls, name, **kwargs)` now draws `arguments-differ` where previously it drew nothing. That's a real signature difference from Django's `(self, cls, name, private_only=False)` rather than a new false positive, but it will show up as new output for people upgrading, so it may deserve a changelog line.

Test is a `func_noerror_` module per the README. Reverting just the one line in fields.py produces the eight `no-member` at the expected lines. `scripts/test.sh` gives 53 passed / 4 skipped against a 52 / 4 baseline, the difference being the new test. Ruff is unchanged at its 13 pre-existing findings.

I left CHANGELOG.rst alone since there's no unreleased section and the README says you handle it at merge. Happy to add an entry if you'd rather.
