### PR TITLE
fix(foreignkey): catch AstroidError when resolving unimportable model module references

### DIFF
--- a/pylint_django/tests/input/func_noerror_foreign_key_missing_module.py
+++ b/pylint_django/tests/input/func_noerror_foreign_key_missing_module.py
@@ -1,0 +1,10 @@
+"""
+Checks that pylint-django does not crash when resolving string references to missing modules.
+"""
+# pylint: disable=missing-docstring
+from django.db import models
+
+
+class TestModel(models.Model):
+    related = models.ForeignKey("loader.TestRelatedModel", on_delete=models.RESTRICT)
+    many = models.ManyToManyField("loader.TestManyModel")

--- a/pylint_django/transforms/foreignkey.py
+++ b/pylint_django/transforms/foreignkey.py
@@ -1,6 +1,13 @@
 from itertools import chain
 
-from astroid import MANAGER, InferenceError, UseInferenceDefault, inference_tip, nodes
+from astroid import (
+    MANAGER,
+    AstroidError,
+    InferenceError,
+    UseInferenceDefault,
+    inference_tip,
+    nodes,
+)
 from astroid.nodes import Attribute, ClassDef
 
 from pylint_django.utils import node_is_subclass
@@ -33,8 +40,11 @@ def _get_model_class_defs_from_module(module, model_name, module_name):
         if isinstance(module_node, nodes.ClassDef) and node_is_subclass(module_node, "django.db.models.base.Model"):
             class_defs.append(module_node)
         elif isinstance(module_node, nodes.ImportFrom):
-            imported_module = module_node.do_import_module()
-            class_defs.extend(_get_model_class_defs_from_module(imported_module, model_name, module_name))
+            try:
+                imported_module = module_node.do_import_module()
+                class_defs.extend(_get_model_class_defs_from_module(imported_module, model_name, module_name))
+            except AstroidError:
+                pass
     return class_defs
 
 
@@ -115,7 +125,10 @@ def infer_key_classes(node, context=None):
 
                 # ensure that module is loaded in astroid_cache, for cases when models is a package
                 if module_name not in MANAGER.astroid_cache:
-                    MANAGER.ast_from_module_name(module_name)
+                    try:
+                        MANAGER.ast_from_module_name(module_name)
+                    except AstroidError:
+                        pass
 
             # create list from dict_values, because it may be modified in a loop
             for module in list(MANAGER.astroid_cache.values()):


### PR DESCRIPTION
… module references

Fixes #480

### Summary
Prevents `AstroidError` / `AstroidImportError` crash when `ForeignKey` or `ManyToManyField` string references point to dynamically generated or unimportable modules (e.g. `loader.TestRelatedModel`).

### Changes
- Handled `AstroidError` around `MANAGER.ast_from_module_name()` and `module_node.do_import_module()` in `pylint_django/transforms/foreignkey.py`.
- Added functional regression test `func_noerror_foreign_key_missing_module.py`.

### Additional Proactive Safety
Beyond handling `MANAGER.ast_from_module_name()` in `infer_key_classes`, this PR also safely handles `AstroidError` during `module_node.do_import_module()` in `_get_model_class_defs_from_module()`. 

This prevents a secondary crash vector when model modules contain unresolved or dynamic `ImportFrom` statements during AST node lookup.

thank you. 